### PR TITLE
Update lrv.c

### DIFF
--- a/robcp/src/lrv.c
+++ b/robcp/src/lrv.c
@@ -210,13 +210,15 @@ SEXP lrv_subs(SEXP ECDF, SEXP L)
   
   int i, j;
   double temp;
-  for(i = 0; i <= n - l; i++)
+  temp = 0;
+  for(j = 0; j < l; j++) {
+    temp += ecdf[j];
+  }
+  sum[0] = fabs(temp - l * 0.5);
+
+  for(i = 1; i <= n - l; i++)
   {
-    temp = 0;
-    for(j = i; j < i + l; j++)
-    {
-      temp += ecdf[j];
-    }
+    temp = temp - ecdf[i-1] + ecdf[i+l-1];
     sum[0] += fabs(temp - l * 0.5);
   }
   


### PR DESCRIPTION
Schau mal bitte, ob das besser ist. Die Berechnung der Summe der F(X_i) wird jetzt upgedated. Das sollte unwesentlich Rechenzeit sparen. O(n) statt O(n*l). l ist ungefähr n^(1/3).